### PR TITLE
fixed three typos

### DIFF
--- a/de.html
+++ b/de.html
@@ -775,7 +775,7 @@ Also, <b></b> bolds a word/phrase, and <i></i> italicizes a word/phrase.
 	... sondern <i>DAS HIER:</i>
 </words>
 <words id="bb_small_world_5">
-	Netzwerkwissenschafler haben nun eine mathematische Definition für dise uralte Einsicht:
+	Netzwerkwissenschaftler haben nun eine mathematische Definition für diese uralte Einsicht:
 	das <b>Kleine-Welt-Netzwerk</b><ref id="small_world"></ref>.
 	Diese optimale Mischung aus Verknüpfungen+Überbrückungen beschreibt, wie
 	unsere Neuronen miteinander verbunden sind<ref id="swn_neurons"></ref>,
@@ -1137,7 +1137,7 @@ Sorry, not done yet! These Bonus Boxes need you to TRANSLATE, too:
 
 	<img src="sprites/bonus/map.png" width="200" height="200" style="float:left; margin-right:1em"/>
 	Merke dir einfach: <b>Alle diese Simulationen sind falsch.</b> Auf die gleiche Art und Weise, wie ein Stadtplan „falsch” ist.
-	Siehst du den Stadplant links? Gebäude sind keine grauen merkmalslosen Klötze!
+	Siehst du den Stadplan links? Gebäude sind keine grauen merkmalslosen Klötze!
 	Wörter schweben nicht über der Stadt! Stadtpläne sind nützlich nicht <i>obwohl</i> sie vereinfacht sind,
 	sondern <i>weil</i> sie vereinfacht sind. Das Gleiche gilt für Simulationen oder jede wissenschaftliche Theorie.
 	<i>Natürlich</i> sind sie „falsch” &mdash; und das ist es, was sie <i>nützlich</i> macht.


### PR DESCRIPTION
This PR just fixes three small typos I found by accident (or should I add this somehow to the PR you opened at the original repo?).
Thanks @berndxfiedler for your valuable corrections!
I guess we can argue about "Du -> du". I once learned that the capitalized version is more polite, didn't know that the nicht-mehr-so-neue Rechtschreibung is not so keen on politeness. Anyway, it's not a letter, so "du" is fine with me.

Not sure though whether "Vernunft" is properly capturing the English "wisdom". Totally agree with using "vernünftig" instead of "weise". But in general, IMHO "Vernunft" denotes rather a neutral behavior (=not dumb) but not necessarily a positive behavior like "wisdom". 
In other words: Crowds can act reasonably, i.e., don't mess things up. However, a *wise* crowd outperforms in a positive way the actions from individuals -- adding on top of "vernünftiges" Verhalten.
Anyway, I don't know of any better word now, so I guess we'll just stick with Vernunft (and Weisheit at a lot of other places ;) ).